### PR TITLE
Remove custom gevent built for RHEL7

### DIFF
--- a/beaker.spec
+++ b/beaker.spec
@@ -235,20 +235,12 @@ Requires:       sudo
 # old style Python package names
 # These LC dependencies are needed in build due to tests
 BuildRequires:  python-lxml
-%if 0%{?rhel} == 7
-BuildRequires:  python2-gevent112
-%else
 BuildRequires:  python-gevent >= 1.0
-%endif
 Requires:       python-cpio
 Requires:       python-setuptools
 Requires:       python-lxml
 Requires:       python-gssapi
-%if 0%{?rhel} == 7
-Requires:       python2-gevent112
-%else
 Requires:       python-gevent >= 1.0
-%endif
 Requires:       python-daemon
 Requires:       python-werkzeug
 Requires:       python-flask


### PR DESCRIPTION
Remove custom python-gevent library.
This library was created by my for Beaker chroot to remove some of the issues which gevent 1.0.
Especially
- SSL is broken due to Python 2.7.9 patch which was backported back to 2.7.5 - RHEL 7
- Socket are not closed automatically - This is huge problem in concurrency
- Gevent yielding is corrupted and hub may remain open for several seconds

As we need initially ease the build pipeline, we should stick with base one provided by RHEL.
