### PR TITLE
Drop obsolete versions

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -9,9 +9,7 @@ jobs:
   trigger: pull_request
   metadata:
     targets:
-      - epel-7-x86_64
       - epel-8-x86_64
-      - fedora-31-x86_64
       - fedora-32-x86_64
       - fedora-33-x86_64
       - fedora-rawhide-x86_64


### PR DESCRIPTION
- EL7 has Python 2.7 by default. Therefore, there is no good reason to continue working on it
- Fedora 31 is close to EOL.