### PR TITLE
Lint code against Python 3

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,6 +1,6 @@
 linters:
   flake8:
-    python: 2
+    python: 3
     max-line-length: 100
     max-complexity: 20
   csslint: {  }


### PR DESCRIPTION
Python 2 is dead.
The new code has to be Python 3 compatible.