### PR TITLE
Drop Python 2 support from CLI

### DIFF
--- a/Client/Makefile
+++ b/Client/Makefile
@@ -4,25 +4,17 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-# Use Python 2 if BKR_PY3 is not defined
-ifeq ($(BKR_PY3),)
-	BKR_PY3 :=0
-endif
-
-COMMAND:= $(shell if [[ $(BKR_PY3) == 0 ]]; then echo "python2"; else echo "python3"; fi)
-
 .PHONY: build
 build:
-	env PYTHONPATH=../Common:src:$${PYTHONPATH:+:$$PYTHONPATH} \
-	    $(COMMAND) setup.py build
+	env PYTHONPATH=../Common:src:$${PYTHONPATH:+:$$PYTHONPATH} python3 setup.py build
 
 .PHONY: install
 install:
-	$(COMMAND) setup.py install -O1 --skip-build --root $(DESTDIR)
+	python3 setup.py install -O1 --skip-build --root $(DESTDIR)
 
 .PHONY: clean
 clean:
-	$(COMMAND) setup.py clean
+	python3 setup.py clean
 	rm -rf build
 
 .PHONY: check

--- a/Client/setup.py
+++ b/Client/setup.py
@@ -4,17 +4,13 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-from setuptools import setup, find_packages
+from subprocess import getstatusoutput
 
-try:
-    from commands import getstatusoutput
-except ImportError:
-    from subprocess import getstatusoutput
+from setuptools import setup, find_packages
 
 
 def bash_completion_dir():
-    status, output = getstatusoutput(
-        'pkg-config --variable completionsdir bash-completion')
+    status, output = getstatusoutput('pkg-config --variable completionsdir bash-completion')
     if status or not output:
         return '/etc/bash_completion.d'
     return output.strip()
@@ -31,7 +27,6 @@ setup(
     install_requires=[
         'beaker-common',
         'lxml',
-        'six',
         'requests',
         'PrettyTable',
         'Jinja2',
@@ -54,7 +49,6 @@ setup(
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Operating System :: POSIX :: Linux',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)',

--- a/Client/src/bkr/client/__init__.py
+++ b/Client/src/bkr/client/__init__.py
@@ -13,12 +13,12 @@ import re
 import sys
 import xml.dom.minidom
 from optparse import OptionGroup
+from urllib.parse import urljoin
 
 import pkg_resources
-from six.moves.urllib_parse import urljoin
 
-from bkr.client.command import Command
 from bkr.common.pyconfig import PyConfigParser
+from bkr.client.command import Command
 
 user_config_file = os.environ.get("BEAKER_CLIENT_CONF", None)
 if not user_config_file:
@@ -28,8 +28,7 @@ if not user_config_file:
         user_config_file = user_conf
     elif os.path.exists(old_conf):
         user_config_file = old_conf
-        sys.stderr.write(
-            "%s is deprecated for config, please use %s instead\n" % (old_conf, user_conf))
+        sys.stderr.write("%s is deprecated for config, please use %s instead\n" % (old_conf, user_conf))
     else:
         pass
 

--- a/Client/src/bkr/client/command.py
+++ b/Client/src/bkr/client/command.py
@@ -10,8 +10,6 @@ import os
 import sys
 from optparse import Option
 
-import six
-
 from bkr.common.hub import HubProxy
 from bkr.common.pyconfig import PyConfigParser
 
@@ -140,7 +138,7 @@ class PluginContainer(object):
         return self._get_plugin(name)
 
     def __iter__(self):
-        return six.iterkeys(self.plugins)
+        return iter(self.plugins.keys())
 
     @classmethod
     def normalize_name(cls, name):
@@ -182,7 +180,7 @@ class PluginContainer(object):
                     normalized_name = normalize_function(plugin_class.__name__)
                     plugins[normalized_name] = plugin_class
 
-            for name, value in six.iteritems(plugins):
+            for name, value in plugins.items():
                 if result.get(name, value) != value:
                     raise RuntimeError(
                         "Cannot register plugin '%s'. "
@@ -371,7 +369,7 @@ class CommandOptionParser(optparse.OptionParser):
         commands = []
         admin_commands = []
 
-        for name, plugin in sorted(six.iteritems(self.container.plugins)):
+        for name, plugin in sorted(self.container.plugins.items()):
             if getattr(plugin, 'hidden', False):
                 continue
             is_admin = getattr(plugin, "admin", False)

--- a/Client/src/bkr/client/commands/cmd_group_members.py
+++ b/Client/src/bkr/client/commands/cmd_group_members.py
@@ -45,8 +45,7 @@ Non-zero on error, otherwise zero.
 from __future__ import print_function
 
 import json
-
-from six.moves.urllib import parse
+from urllib import parse
 
 from bkr.client import BeakerCommand
 

--- a/Client/src/bkr/client/commands/cmd_group_modify.py
+++ b/Client/src/bkr/client/commands/cmd_group_modify.py
@@ -101,8 +101,7 @@ See also
 :manpage:`bkr(1)`
 
 """
-
-from six.moves.urllib import parse
+from urllib import parse
 
 from bkr.client import BeakerCommand
 

--- a/Client/src/bkr/client/commands/cmd_job_clone.py
+++ b/Client/src/bkr/client/commands/cmd_job_clone.py
@@ -88,7 +88,6 @@ from __future__ import print_function
 import sys
 
 import lxml.etree
-import six
 
 from bkr.client import BeakerCommand
 from bkr.client.task_watcher import *
@@ -167,12 +166,10 @@ class Job_Clone(BeakerCommand):
                                                   pretty_print=pretty,
                                                   xml_declaration=True,
                                                   encoding='utf8')
-                    if six.PY3:
-                        str_xml = str_xml.decode('utf-8')
+                    str_xml = str_xml.decode('utf-8')
                     print(str_xml)
                 if not dryrun:
-                    submitted_jobs.append(self.hub.jobs.upload(
-                        jobxml.decode('utf-8') if six.PY3 else jobxml))
+                    submitted_jobs.append(self.hub.jobs.upload(jobxml.decode('utf-8')))
                     print("Submitted: %s" % submitted_jobs)
             except (KeyboardInterrupt, SystemError):
                 raise

--- a/Client/src/bkr/client/commands/cmd_job_modify.py
+++ b/Client/src/bkr/client/commands/cmd_job_modify.py
@@ -108,9 +108,9 @@ See also
 from __future__ import print_function
 
 import sys
+from xmlrpc.client import Fault
 
 import requests
-from six.moves.xmlrpc_client import Fault
 
 from bkr.client import BeakerCommand
 

--- a/Client/src/bkr/client/commands/cmd_job_results.py
+++ b/Client/src/bkr/client/commands/cmd_job_results.py
@@ -77,7 +77,6 @@ See also
 from __future__ import print_function
 
 import lxml.etree
-import six
 
 from bkr.client import BeakerCommand
 
@@ -129,8 +128,7 @@ class Job_Results(BeakerCommand):
                                               pretty_print=prettyxml,
                                               xml_declaration=prettyxml,
                                               encoding='utf-8')
-                if six.PY3:  # Decode bytes to string (otherwise print will be broken)
-                    str_xml = str_xml.decode('utf-8')
+                str_xml = str_xml.decode('utf-8')
                 print(str_xml)
             elif format == 'junit-xml':
                 type, colon, id = task.partition(':')

--- a/Client/src/bkr/client/commands/cmd_job_submit.py
+++ b/Client/src/bkr/client/commands/cmd_job_submit.py
@@ -107,7 +107,6 @@ import xml.dom.minidom
 
 import lxml.etree
 import pkg_resources
-import six
 
 from bkr.client import BeakerCommand
 from bkr.client.convert import Convert
@@ -221,11 +220,8 @@ stdin."""
         jobxmls = []
         for job in jobs:
             if job == '-':
-                if six.PY3:  # Handle piped non UTF-8 data
-                    with open(0, 'rb') as f:
-                        mystring = f.read()
-                else:
-                    mystring = sys.stdin.read()
+                with open(0, 'rb') as f:
+                    mystring = f.read()
             else:
                 mystring = open(job, "r").read()
             try:

--- a/Client/src/bkr/client/commands/cmd_labcontroller_modify.py
+++ b/Client/src/bkr/client/commands/cmd_labcontroller_modify.py
@@ -88,8 +88,7 @@ See also
 :manpage:`bkr labcontroller-list(1)`
 
 """
-
-from six.moves.urllib import parse
+from urllib import parse
 
 from bkr.client import BeakerCommand
 

--- a/Client/src/bkr/client/commands/cmd_loan_grant.py
+++ b/Client/src/bkr/client/commands/cmd_loan_grant.py
@@ -67,8 +67,7 @@ See also
 
 :manpage:`bkr(1)`
 """
-
-from six.moves.urllib import parse
+from urllib import parse
 
 from bkr.client import BeakerCommand
 

--- a/Client/src/bkr/client/commands/cmd_loan_return.py
+++ b/Client/src/bkr/client/commands/cmd_loan_return.py
@@ -52,8 +52,7 @@ See also
 
 :manpage:`bkr(1)`
 """
-
-from six.moves.urllib import parse
+from urllib import parse
 
 from bkr.client import BeakerCommand
 

--- a/Client/src/bkr/client/commands/cmd_policy_grant.py
+++ b/Client/src/bkr/client/commands/cmd_policy_grant.py
@@ -79,8 +79,7 @@ See also
 
 :manpage:`bkr(1)`, :manpage:`bkr-policy-revoke(1)`
 """
-
-from six.moves.urllib import parse
+from urllib import parse
 
 from bkr.client import BeakerCommand
 

--- a/Client/src/bkr/client/commands/cmd_policy_list.py
+++ b/Client/src/bkr/client/commands/cmd_policy_list.py
@@ -83,9 +83,9 @@ See also
 from __future__ import print_function
 
 import json
+from urllib import parse
 
 from prettytable import PrettyTable
-from six.moves.urllib import parse
 
 from bkr.client import BeakerCommand
 

--- a/Client/src/bkr/client/commands/cmd_policy_revoke.py
+++ b/Client/src/bkr/client/commands/cmd_policy_revoke.py
@@ -84,8 +84,7 @@ See also
 
 :manpage:`bkr(1)`, :manpage:`bkr-policy-grant(1)`
 """
-
-from six.moves.urllib import parse
+from urllib import parse
 
 from bkr.client import BeakerCommand
 

--- a/Client/src/bkr/client/commands/cmd_pool_add.py
+++ b/Client/src/bkr/client/commands/cmd_pool_add.py
@@ -62,8 +62,7 @@ See also
 :manpage:`bkr(1)`, :manpage:`bkr-pool-remove(1)`
 
 """
-
-from six.moves.urllib import parse
+from urllib import parse
 
 from bkr.client import BeakerCommand
 

--- a/Client/src/bkr/client/commands/cmd_pool_delete.py
+++ b/Client/src/bkr/client/commands/cmd_pool_delete.py
@@ -45,9 +45,7 @@ See also
 :manpage:`bkr(1)`, :manpage:`bkr pool-create`, :manpage:`bkr pool-modify`
 
 """
-
-
-from six.moves.urllib import parse
+from urllib import parse
 
 from bkr.client import BeakerCommand
 

--- a/Client/src/bkr/client/commands/cmd_pool_remove.py
+++ b/Client/src/bkr/client/commands/cmd_pool_remove.py
@@ -62,8 +62,7 @@ See also
 :manpage:`bkr(1)`, :manpage:`bkr-pool-add(1)`
 
 """
-
-from six.moves.urllib import parse
+from urllib import parse
 
 from bkr.client import BeakerCommand
 

--- a/Client/src/bkr/client/commands/cmd_system_details.py
+++ b/Client/src/bkr/client/commands/cmd_system_details.py
@@ -54,7 +54,7 @@ See also
 
 from __future__ import print_function
 
-from six.moves.urllib import parse
+from urllib import parse
 
 from bkr.client import BeakerCommand
 

--- a/Client/src/bkr/client/commands/cmd_system_history_list.py
+++ b/Client/src/bkr/client/commands/cmd_system_history_list.py
@@ -70,9 +70,9 @@ See also
 from __future__ import print_function
 
 import json
+import xmlrpc.client
 
 from datetime import datetime
-from six.moves import xmlrpc_client
 
 from bkr.client import BeakerCommand
 
@@ -81,7 +81,7 @@ def json_serial(obj):
     """
     JSON serializer for objects not serializable by default json code
     """
-    if isinstance(obj, xmlrpc_client.DateTime):
+    if isinstance(obj, xmlrpc.client.DateTime):
         return obj.value
     raise TypeError("Type %s not serializable" % type(obj))
 

--- a/Client/src/bkr/client/commands/cmd_system_list.py
+++ b/Client/src/bkr/client/commands/cmd_system_list.py
@@ -138,10 +138,9 @@ from __future__ import print_function
 
 import optparse
 import sys
+from urllib import parse
 
 import lxml.etree
-import six
-from six.moves.urllib import parse
 
 from bkr.client import BeakerCommand, host_filter_presets
 
@@ -223,7 +222,7 @@ class System_List(BeakerCommand):
             ('tg_format', 'atom'),
             ('list_tgp_limit', 0),
         ]
-        for i, x in enumerate(six.iteritems(self.search)):
+        for i, x in enumerate(self.search.items()):
             if kwargs[x[0]]:
                 qs_args.extend([
                     ('systemsearch-%d.table' % i, x[1]),

--- a/Client/src/bkr/client/commands/cmd_system_modify.py
+++ b/Client/src/bkr/client/commands/cmd_system_modify.py
@@ -117,8 +117,7 @@ See also
 
 :manpage:`bkr(1)`
 """
-
-from six.moves.urllib import parse
+from urllib import parse
 
 from bkr.client import BeakerCommand
 

--- a/Client/src/bkr/client/commands/cmd_system_release.py
+++ b/Client/src/bkr/client/commands/cmd_system_release.py
@@ -56,8 +56,7 @@ See also
 
 :manpage:`bkr(1)`
 """
-
-from six.moves.urllib import parse
+from urllib import parse
 
 from bkr.client import BeakerCommand
 

--- a/Client/src/bkr/client/commands/cmd_system_status.py
+++ b/Client/src/bkr/client/commands/cmd_system_status.py
@@ -54,8 +54,7 @@ See also
 from __future__ import print_function
 
 from json import loads
-
-from six.moves.urllib import parse
+from urllib import parse
 
 from bkr.client import BeakerCommand
 

--- a/Client/src/bkr/client/commands/cmd_task_add.py
+++ b/Client/src/bkr/client/commands/cmd_task_add.py
@@ -55,8 +55,7 @@ from __future__ import print_function
 
 import os.path
 import sys
-
-from six.moves import xmlrpc_client
+import xmlrpc.client
 
 from bkr.client import BeakerCommand
 
@@ -77,7 +76,7 @@ class Task_Add(BeakerCommand):
         failed = False
         for task in tasks:
             task_name = os.path.basename(task)
-            task_binary = xmlrpc_client.Binary(open(task, "rb").read())
+            task_binary = xmlrpc.client.Binary(open(task, "rb").read())
             print(task_name)
             try:
                 print(self.hub.tasks.upload(task_name, task_binary))

--- a/Client/src/bkr/client/commands/cmd_task_delete.py
+++ b/Client/src/bkr/client/commands/cmd_task_delete.py
@@ -57,8 +57,7 @@ from __future__ import print_function
 
 import json
 import sys
-
-from six.moves import xmlrpc_client
+from xmlrpc.client import Fault
 
 from bkr.client import BeakerCommand
 
@@ -85,7 +84,7 @@ class Task_Delete(BeakerCommand):
                 failed = not output['success']
             except (KeyboardInterrupt, SystemExit):
                 raise
-            except xmlrpc_client.Fault as ex:
+            except Fault as ex:
                 failed = True
                 sys.stderr.write(ex.faultString + '\n')
             except Exception as ex:

--- a/Client/src/bkr/client/commands/cmd_watchdog_extend.py
+++ b/Client/src/bkr/client/commands/cmd_watchdog_extend.py
@@ -61,8 +61,7 @@ See also
 
 :manpage:`bkr(1)`
 """
-
-from six.moves.urllib import parse
+from urllib import parse
 
 from bkr.client import BeakerCommand
 

--- a/Client/src/bkr/client/commands/cmd_workflow_simple.py
+++ b/Client/src/bkr/client/commands/cmd_workflow_simple.py
@@ -58,8 +58,7 @@ from __future__ import print_function
 
 import sys
 import xml.dom.minidom
-
-from six.moves.xmlrpc_client import Fault
+from xmlrpc.client import Fault
 
 from bkr.client import BeakerJob
 from bkr.client import BeakerRecipe

--- a/Client/src/bkr/client/commands/cmd_workflow_xslt.py
+++ b/Client/src/bkr/client/commands/cmd_workflow_xslt.py
@@ -4,14 +4,13 @@
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
-
+import configparser
 import os
 import re
 import sys
 from optparse import OptionValueError, OptionGroup
 
 from lxml import etree
-from six.moves import configparser
 
 from bkr.client import BeakerCommand
 from bkr.client.task_watcher import *
@@ -610,7 +609,7 @@ class JobDefaults(configparser.ConfigParser):
                     )
         self.read(deffiles)
 
-    def read(self, fname):
+    def read(self, fname, **kwargs):
         """
         Wrapper around ConfigParser.ConfigParser.read()
         """

--- a/Client/src/bkr/client/task_watcher.py
+++ b/Client/src/bkr/client/task_watcher.py
@@ -8,8 +8,6 @@
 from __future__ import print_function
 
 import sys
-
-import six
 import time
 
 __all__ = (
@@ -21,7 +19,7 @@ __all__ = (
 def display_tasklist_status(task_list):
     state_dict = {}
     for task in task_list:
-        for state, value in six.iteritems(task.get_state_dict()):
+        for state, value in task.get_state_dict().items():
             state_dict.setdefault(state, 0)
             state_dict[state] += value
     print("--> " + " ".join(("%s: %s" % (key, state_dict[key])
@@ -79,7 +77,7 @@ class TaskWatcher(object):
             return False
 
         result = task.task_info.get("is_finished", False)
-        for subtask in six.itervalues(self.subtask_dict):
+        for subtask in self.subtask_dict.values():
             result &= subtask.is_finished()
         return result
 
@@ -89,7 +87,7 @@ class TaskWatcher(object):
             return False
 
         result = task.task_info.get("is_failed", False)
-        for subtask in six.itervalues(self.subtask_dict):
+        for subtask in self.subtask_dict.values():
             result |= subtask.is_failed()
         return result
 
@@ -159,8 +157,8 @@ class Task(object):
             state_dict.setdefault(state, 0)
             state_dict[state] += 1
 
-        for subtask in six.itervalues(self.subtask_dict):
-            for state, value in six.iteritems(subtask.get_state_dict()):
+        for subtask in self.subtask_dict.values():
+            for state, value in subtask.get_state_dict().items():
                 state_dict.setdefault(state, 0)
                 state_dict[state] += value
 


### PR DESCRIPTION
Python 2 is dead. Let's start dropping support and port everything to Python 3 only.