### PR TITLE
Python 3 workflow for GitHub checks

### DIFF
--- a/.github/workflows/review-checks.yml
+++ b/.github/workflows/review-checks.yml
@@ -20,6 +20,7 @@ jobs:
         dnf builddep *.spec -y
     - name: Build documentation
       run: |
+        export BKR_PY3=1
         make -C documentation html SPHINXOPTS="-W"
         mv documentation/_build/html /__w
     - uses: actions/upload-artifact@v1

--- a/.github/workflows/review-checks.yml
+++ b/.github/workflows/review-checks.yml
@@ -12,7 +12,8 @@ jobs:
     - uses: actions/checkout@v1
     - name: Install Beaker dependency from specfile
       run: |
-        yum-builddep *.spec -y
+        dnf install 'dnf-command(builddep)' -y
+        dnf builddep *.spec -y
     - name: Build documentation
       run: |
         make -C documentation html SPHINXOPTS="-W"

--- a/.github/workflows/review-checks.yml
+++ b/.github/workflows/review-checks.yml
@@ -6,7 +6,7 @@ jobs:
   check-docs:
     runs-on: ubuntu-latest
     container:
-      image: centos:7
+      image: centos:8
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/review-checks.yml
+++ b/.github/workflows/review-checks.yml
@@ -18,10 +18,13 @@ jobs:
       run: |
         dnf install 'dnf-command(builddep)' -y
         dnf builddep *.spec -y
+    - name: Install python3-sphinxcontrib-httpdomain from Fedora repo
+      run: |
+        dnf install https://kojipkgs.fedoraproject.org//vol/fedora_koji_archive02/packages/python-sphinxcontrib-httpdomain/1.7.0/1.fc28/noarch/python3-sphinxcontrib-httpdomain-1.7.0-1.fc28.noarch.rpm -y
     - name: Build documentation
       run: |
         export BKR_PY3=1
-        make -C documentation html SPHINXOPTS="-W"
+        make -C documentation html
         mv documentation/_build/html /__w
     - uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/review-checks.yml
+++ b/.github/workflows/review-checks.yml
@@ -10,6 +10,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+    - name: Enable CentOS PowerTools repo
+      run: |
+        dnf install 'dnf-command(config-manager)' -y
+        dnf config-manager --set-enabled PowerTools
     - name: Install Beaker dependency from specfile
       run: |
         dnf install 'dnf-command(builddep)' -y

--- a/.github/workflows/review-checks.yml
+++ b/.github/workflows/review-checks.yml
@@ -10,12 +10,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Install utils
-      run: |
-        yum install -y git wget
-    - name: Fetch Beaker repository
-      run: |
-        wget https://beaker-project.org/yum/beaker-server-RedHatEnterpriseLinux.repo -P /etc/yum.repos.d/
     - name: Install Beaker dependency from specfile
       run: |
         yum-builddep *.spec -y


### PR DESCRIPTION
Use `CentOS 8` as base image for docs build.
At this moment build is limited to common and client (same as fedora builds), because the server and lab controller is Python 2 at this moment. 